### PR TITLE
syntax error; which causes:

### DIFF
--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -89,7 +89,7 @@ define mit_krb5::realm(
   })
   concat::fragment { "mit_krb5::realm::${title}":
     target  => $mit_krb5::krb5_conf_path,
-    order   => "11realm_${title}"
+    order   => "11realm_${title}",
     content => template('mit_krb5/realm.erb'),
   }
 }


### PR DESCRIPTION
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Syntax error at 'content' at modules/mit_krb5/manifests/realm.pp:93:5 on node
